### PR TITLE
Fix iPad preview removal on viewWillDisappear

### DIFF
--- a/VisualActivityViewController.swift
+++ b/VisualActivityViewController.swift
@@ -183,8 +183,11 @@ final class VisualActivityViewController: UIActivityViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        UIView.animate(withDuration: fadeOutDuration) {
-            self.preview?.alpha = 0
+        UIView.animate(withDuration: fadeOutDuration,
+                       animations: {
+                        self.preview?.alpha = 0;
+        }) { (Bool) in
+            self.preview? .removeFromSuperview()
         }
     }
     

--- a/VisualActivityViewController.swift
+++ b/VisualActivityViewController.swift
@@ -185,7 +185,7 @@ final class VisualActivityViewController: UIActivityViewController {
         
         UIView.animate(withDuration: fadeOutDuration, animations: {
             self.preview?.alpha = 0;
-        }) {_ in
+        }) { _ in
             self.preview?.removeFromSuperview()
         }
     }

--- a/VisualActivityViewController.swift
+++ b/VisualActivityViewController.swift
@@ -184,7 +184,7 @@ final class VisualActivityViewController: UIActivityViewController {
         super.viewWillDisappear(animated)
         
         UIView.animate(withDuration: fadeOutDuration, animations: {
-            self.preview?.alpha = 0;
+            self.preview?.alpha = 0
         }) { _ in
             self.preview?.removeFromSuperview()
         }

--- a/VisualActivityViewController.swift
+++ b/VisualActivityViewController.swift
@@ -183,11 +183,10 @@ final class VisualActivityViewController: UIActivityViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        UIView.animate(withDuration: fadeOutDuration,
-                       animations: {
-                        self.preview?.alpha = 0;
-        }) { (Bool) in
-            self.preview? .removeFromSuperview()
+        UIView.animate(withDuration: fadeOutDuration, animations: {
+            self.preview?.alpha = 0;
+        }) {_ in
+            self.preview?.removeFromSuperview()
         }
     }
     


### PR DESCRIPTION
fixes issue where preview remained on screen (but not visible) after viewWillDisappear on iPad.
This fixes #4