### PR TITLE
Expose all properties in Objective C

### DIFF
--- a/VisualActivityViewController.swift
+++ b/VisualActivityViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class VisualActivityViewController: UIActivityViewController {
+@objcMembers final class VisualActivityViewController: UIActivityViewController {
     
     /// The preview container view
     private var preview: UIVisualEffectView!


### PR DESCRIPTION
Added `@objcMembers` prefix to class.

This will expose the class properties to objective c, in the same way as they are exposed already in Swift.

Closes issue #6 